### PR TITLE
fix the name for the application listing renderers

### DIFF
--- a/config/metadata.config.php
+++ b/config/metadata.config.php
@@ -17,7 +17,7 @@ return array(
         16 => 'static/apps/novius_onlinemediafiles/img/16-icon.png',
     ),
     'requires' => array(
-        'lib_renderers',
+        'novius_renderers',
     ),
     'permission' => array(),
     'provider' => array(


### PR DESCRIPTION
It should use the new name of the application.
