### PR TITLE
Give classname in online media files

### DIFF
--- a/classes/controller/admin/ajax.ctrl.php
+++ b/classes/controller/admin/ajax.ctrl.php
@@ -34,7 +34,7 @@ class Controller_Admin_Ajax extends \Nos\Controller_Admin_Application
                 \Arr::merge(
                     $test_item->driver()->attributes(),
                     array(
-                        'driver_name'   => '\\' . $test_item->driver()->className(),
+                        'driver_name'   => $test_item->driver()->driverName(),
                         'driver_icon'   => $test_item->driver()->driverIcon(),
                         'display'       => $test_item->driver()->display(),
                         'preview'       => $test_item->driver()->preview(),

--- a/classes/controller/admin/ajax.ctrl.php
+++ b/classes/controller/admin/ajax.ctrl.php
@@ -34,7 +34,7 @@ class Controller_Admin_Ajax extends \Nos\Controller_Admin_Application
                 \Arr::merge(
                     $test_item->driver()->attributes(),
                     array(
-                        'driver_name'   => $test_item->driver()->driverName(),
+                        'driver_name'   => '\\' . $test_item->driver()->className(),
                         'driver_icon'   => $test_item->driver()->driverIcon(),
                         'display'       => $test_item->driver()->display(),
                         'preview'       => $test_item->driver()->preview(),

--- a/classes/driver.php
+++ b/classes/driver.php
@@ -60,6 +60,11 @@ abstract class Driver {
      * @return string
      */
     public static function buildDriverName($driver_class) {
+        $currentNamespace = __NAMESPACE__;
+        $driverNamespace = substr($driver_class, 0, strrpos($driver_class, '\\'));
+        if ($currentNamespace != $driverNamespace) {
+            return '\\' .$driver_class;
+        }
         return substr($driver_class, strrpos($driver_class, '\\') + 1);
     }
 


### PR DESCRIPTION
The ajax controller return the driverName, which only works with bundled drivers. For custom driver we need the fully specified className, hence this modification.