### PR TITLE
bugfix icon

### DIFF
--- a/classes/driver.php
+++ b/classes/driver.php
@@ -348,13 +348,9 @@ abstract class Driver {
      * @return mixed
      */
     public function driverIcon($size = 16) {
-        $icon = \Arr::get($this->config, 'icon.'.$size);
-
-        if (mb_strpos($icon, '/') === false) {
-            $icon = 'static/apps/novius_onlinemediafiles/icons/'.$size.'/'.$icon;
-        }
-
-		return $icon;
+        $icon = \Arr::get($this->config, 'icon.' . $size);
+        $icon = 'static/apps/novius_onlinemediafiles/icons/' . $size . '/' . $icon;
+        return $icon;
     }
 
     /**


### PR DESCRIPTION
Since the icon is used in both the crud and the inspector, we always need to append the application static directory, even for custom drivers.

In the appdeks inspector we have to give an icon as a filename, the applications' static path will automatically be prepended.

  inspector/appdesk.config.php
  data => (array('icon' => 'test.png')) // static/apps/nameofapp/icons/16/test.png

In the crud it is displayed with the driverIcon() method. For consistency we need to prepend the static path to this method as well, the condition was creating the bug.
