### PR TITLE
Remove default path for icons

### DIFF
--- a/classes/driver.php
+++ b/classes/driver.php
@@ -350,11 +350,14 @@ abstract class Driver {
     public function driverIcon($size = 16) {
         $icon = \Arr::get($this->config, 'icon.'.$size);
 
+        return static::driverIconPath($size, $icon);
+    }
+
+    public static function driverIconPath($size, $icon) {
         if (mb_strpos($icon, '/') === false) {
             $icon = 'static/apps/novius_onlinemediafiles/icons/'.$size.'/'.$icon;
         }
-
-		return $icon;
+        return $icon;
     }
 
     /**

--- a/config/controller/admin/inspector/driver.config.php
+++ b/config/controller/admin/inspector/driver.config.php
@@ -47,7 +47,7 @@ foreach ($config['drivers'] as $driver_name) {
 	$data[] = array(
 		'id' 	=> $driver_name,
 		'title' => $title,
-		'icon' 	=> \Arr::get($driver_config, 'icon.16'),
+		'icon' 	=> \Novius\OnlineMediaFiles\Driver::driverIconPath(16,\Arr::get($driver_config, 'icon.16')),
 	);
 }
 

--- a/static/config/common.js
+++ b/static/config/common.js
@@ -23,7 +23,7 @@ define(
                                             if ($.isPlainObject(args.row.data)) {
                                                 var text = "";
                                                 if (args.row.data.icon) {
-                                                    text += "<img style=\"vertical-align:middle\" src=\"static/apps/novius_onlinemediafiles/icons/16/" + args.row.data.icon + "\"> ";
+                                                    text += "<img style=\"vertical-align:middle\" src=\"" + args.row.data.icon + "\"> ";
                                                 }
                                                 text += args.row.data.title;
 


### PR DESCRIPTION
A default path was used in JS for the icons, it was causing a strange behaviour. Now all path are fully specified and not magically created, at least we won't be searching for this bug anymore. :triumph: