### PR TITLE
Handle duplicates

### DIFF
--- a/classes/controller/admin/ajax.ctrl.php
+++ b/classes/controller/admin/ajax.ctrl.php
@@ -19,6 +19,20 @@ class Controller_Admin_Ajax extends \Nos\Controller_Admin_Application
                 throw new \Exception(__('Please specify the URL of the online media'));
             }
 
+            $config = \Config::load("novius_onlinemediafiles::config", true);
+            if (!\Arr::get($config, 'allow_duplicates', false)) {
+                // Find existing media
+                $foundMedia = Model_Media::query()->where('onme_url', $url)->get_one();
+
+                if (!empty($foundMedia)) {
+                    \Response::json(200,
+                        array(
+                            'id' => $foundMedia->onme_id
+                        )
+                    );
+                }
+            }
+
             // Builds a test item
             $test_item = Model_Media::forge(array(
                 'onme_url'  => $url,

--- a/config/config.php
+++ b/config/config.php
@@ -38,4 +38,5 @@ return array(
         // Enable or disable the responsive features
         'enabled'   => false,
     ),
+    'allow_duplicates' => false
 );

--- a/static/js/admin/sync_video.js
+++ b/static/js/admin/sync_video.js
@@ -90,6 +90,20 @@ define(
                             return ;
                         }
 
+                        var id = json.id;
+                        if (id) {
+                            var vars = {};
+                            var parts = window.location.href.replace(/[?&]+([^=&]+)=([^&]*)/gi, function(m,key,value) {
+                                vars[key] = value;
+                            });
+                            url = vars['tab'] + '/' + id;
+                            $wrapper_btn.nosTabs('update', {
+                                url: url,
+                                reload: true
+                            });
+                            return;
+                        }
+
                         // Update fields
                         $title.val(json.title);
                         $description.val(json.description);

--- a/views/admin/sync_video.view.php
+++ b/views/admin/sync_video.view.php
@@ -14,7 +14,7 @@ $wrapper_button_id = uniqid('wrapper_button_');
 $btn_synchro_id = uniqid('btn_synchro_');
 ?>
 <script type="text/javascript">
-    require(['jquery-nos', 'static/apps/novius_onlinemediafiles/js/admin/sync_video.js'],
+    require(['jquery-nos', 'static/apps/novius_onlinemediafiles/js/admin/sync_video.js?v=1'],
         function ($, callback_fn) {
             $(function () {
                 callback_fn.call($('#<?= $wrapper_button_id ?>'), $('#<?= $btn_synchro_id ?>'), <?= intval($item->onme_id) ?>, '<?= $fieldset->form()->get_attribute('id') ?>');


### PR DESCRIPTION
Hi,

I added a functionality to avoid saving the same video twice in the app. With the modification, if a media with the same url is already inserted, we will switch the tab to the correct item instead of inserting a new one.

If we really need to allow this behaviour, there is a configuration key available.