### PR TITLE
Ask the user before redirecting to the existing media + bugfix on redirect url

### DIFF
--- a/classes/controller/admin/ajax.ctrl.php
+++ b/classes/controller/admin/ajax.ctrl.php
@@ -14,20 +14,25 @@ class Controller_Admin_Ajax extends \Nos\Controller_Admin_Application
 {
     public function action_fetch() {
         try {
+            $onme_id = \Input::post('onme_id');
             $url = \Input::post('url', false);
             if (empty($url)) {
                 throw new \Exception(__('Please specify the URL of the online media'));
             }
 
+            // Prevents duplicate media
             $config = \Config::load("novius_onlinemediafiles::config", true);
             if (!\Arr::get($config, 'allow_duplicates', false)) {
-                // Find existing media
-                $foundMedia = Model_Media::query()->where('onme_url', $url)->get_one();
-
+                // Search another media with the same url
+                $foundMedia = Model_Media::query()->where('onme_url', $url);
+                if (!empty($onme_id)) {
+                    $foundMedia->where('onme_id', '!=', $onme_id);
+                }
+                $foundMedia = $foundMedia->get_one();
                 if (!empty($foundMedia)) {
                     \Response::json(200,
                         array(
-                            'id' => $foundMedia->onme_id
+                            'duplicate_of' => 'admin/novius_onlinemediafiles/media/insert_update/'.$foundMedia->onme_id
                         )
                     );
                 }

--- a/static/js/admin/sync_video.js
+++ b/static/js/admin/sync_video.js
@@ -81,7 +81,8 @@ define(
                 $wrapper_btn.nosAjax({
                     url: 'admin/novius_onlinemediafiles/ajax/fetch',
                     data: {
-                        'url' : url
+                        'url'       : url,
+                        'onme_id'   : onme_id
                     },
                     dataType    : 'json',
                     type        : 'POST',
@@ -90,17 +91,14 @@ define(
                             return ;
                         }
 
-                        var id = json.id;
-                        if (id) {
-                            var vars = {};
-                            var parts = window.location.href.replace(/[?&]+([^=&]+)=([^&]*)/gi, function(m,key,value) {
-                                vars[key] = value;
-                            });
-                            url = vars['tab'] + '/' + id;
-                            $wrapper_btn.nosTabs('update', {
-                                url: url,
-                                reload: true
-                            });
+                        if (json.duplicate_of) {
+                            // @todo make a nice confirmationDialog
+                            if (confirm('An online media with the same URL already exists, would you like to be redirected to this one ?')) {
+                                $wrapper_btn.nosTabs('open', {
+                                    url: json.duplicate_of,
+                                    reload: true
+                                });
+                            }
                             return;
                         }
 


### PR DESCRIPTION
- The redirect wasn't working as expected (the existing ID was added after the current ID), it's now fixed.
- Adds a native javascript confirm dialog to ask the user if he wants to be redirected (otherwise he doesn't know what happens).
- Changes the nosTab action to "open" instead of "replace" to avoid duplicate tabs.
