### PR TITLE
Vimeo player can now only be fetched using SSL (used for private videos)

### DIFF
--- a/classes/driver/vimeo.php
+++ b/classes/driver/vimeo.php
@@ -191,7 +191,7 @@ class Driver_Vimeo extends Driver {
         );
 
         // Get player content
-        $player_url = 'http://player.vimeo.com/video/'.$this->identifier();
+        $player_url = 'https://player.vimeo.com/video/'.$this->identifier();
         $player_content = static::get_url_content($player_url);
 
         // Extract title


### PR DESCRIPTION
Fetching a private video from Vimeo using the "player" wasn't working anymore because SSL is now required.